### PR TITLE
Upgrade dependencies and modernize Java code

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Extract version from release tag
+        id: version
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Set project version
+        run: mvn --batch-mode versions:set -DnewVersion=${{ steps.version.outputs.version }} -DgenerateBackupPoms=false
+
+      - name: Build
+        run: mvn --batch-mode package
+
+      - name: Upload release artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          gh release upload "${{ github.event.release.tag_name }}" \
+            target/netsimulator-${VERSION}-bin.tar.gz \
+            target/netsimulator-${VERSION}-bin.tar.bz2 \
+            target/netsimulator-${VERSION}-bin.zip

--- a/pom.xml
+++ b/pom.xml
@@ -17,12 +17,12 @@
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
-            <version>1.4</version>
+            <version>1.9.0</version>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.14.0</version>
         </dependency>
         <dependency>
             <groupId>xalan</groupId>
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
-            <version>2.12.0</version>
+            <version>2.12.2</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -66,9 +66,11 @@
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.5.3</version>
+                <version>3.7.1</version>
                 <configuration>
-                    <descriptor>src/assembly/dep.xml</descriptor>
+                    <descriptors>
+                        <descriptor>src/assembly/dep.xml</descriptor>
+                    </descriptors>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     <version>1.1.0</version>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/src/main/java/org/netsimulator/net/ARPCache.java
+++ b/src/main/java/org/netsimulator/net/ARPCache.java
@@ -55,23 +55,21 @@ public class ARPCache {
     }
 
     public void put(IP4Address key, MACAddress value) {
-        if(lock.tryLock()) {
-            try{
-                cache.put(key, new ResolvedAddress(value, System.currentTimeMillis()));
-            } finally {
-                lock.unlock();
-            }
+        lock.lock();
+        try {
+            cache.put(key, new ResolvedAddress(value, System.currentTimeMillis()));
+        } finally {
+            lock.unlock();
         }
     }
 
     public MACAddress get(IP4Address key) {
         MACAddress resolvedAddress = null;
-        if(lock.tryLock()) {
-            try {
-                resolvedAddress = cache.get(key) == null ? null : cache.get(key).resolvedAddress;
-            } finally {
-                lock.unlock();
-            }
+        lock.lock();
+        try {
+            resolvedAddress = cache.get(key) == null ? null : cache.get(key).resolvedAddress;
+        } finally {
+            lock.unlock();
         }
         return resolvedAddress;
     }
@@ -80,20 +78,20 @@ public class ARPCache {
      * Clean records
      */
     public void clean() {
-        if(lock.tryLock()) {
-            logger.finest("Clean ARP cache job is running.");
-            try {
-                for (IP4Address ip4Address: cache.keySet()) {               
-                    ResolvedAddress addr = cache.get(ip4Address);
-                    long offset = (System.currentTimeMillis() - addr.resolvedTime) / 1000;
-                    if (offset > timeout) {
-                        logger.log(Level.FINEST, "{0} -> {1} time sinse has been resolved {2}, going to be removed.", new Object[]{ip4Address, addr.resolvedAddress, offset});
-                        cache.remove(ip4Address);
-                    }
+        lock.lock();
+        logger.finest("Clean ARP cache job is running.");
+        try {
+            cache.entrySet().removeIf(entry -> {
+                long offset = (System.currentTimeMillis() - entry.getValue().resolvedTime) / 1000;
+                if (offset > timeout) {
+                    logger.log(Level.FINEST, "{0} -> {1} time sinse has been resolved {2}, going to be removed.",
+                            new Object[]{entry.getKey(), entry.getValue().resolvedAddress, offset});
+                    return true;
                 }
-            } finally {
-                lock.unlock();
-            }
+                return false;
+            });
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -102,7 +100,7 @@ public class ARPCache {
      * @return resolved addresses.
      */    
     public List<IP4Address> getAddresses() {
-        List<IP4Address> res = Collections.EMPTY_LIST;
+        List<IP4Address> res = Collections.emptyList();
         lock.lock();
         try {
             res = new LinkedList<IP4Address>(cache.keySet());

--- a/src/main/java/org/netsimulator/net/EthernetInterface.java
+++ b/src/main/java/org/netsimulator/net/EthernetInterface.java
@@ -24,10 +24,10 @@ import org.netsimulator.util.ConfigurableThreadFactory;
 import org.netsimulator.util.IdGenerator;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -55,14 +55,14 @@ public class EthernetInterface
     private int status;
     private int bandwidth;
     private String encap;
-    private int rxBytes;
-    private int txBytes;
-    private int rxPackets;
-    private int txPackets;
-    private int rxPacketsErrors;
-    private int txPacketsErrors;
-    private int rxDroped;
-    private int txDroped;
+    private final AtomicInteger rxBytes = new AtomicInteger(0);
+    private final AtomicInteger txBytes = new AtomicInteger(0);
+    private final AtomicInteger rxPackets = new AtomicInteger(0);
+    private final AtomicInteger txPackets = new AtomicInteger(0);
+    private final AtomicInteger rxPacketsErrors = new AtomicInteger(0);
+    private final AtomicInteger txPacketsErrors = new AtomicInteger(0);
+    private final AtomicInteger rxDroped = new AtomicInteger(0);
+    private final AtomicInteger txDroped = new AtomicInteger(0);
     private ARPCache arpCache;
     private String name;
     private ArrayList<TransferPacketListener> transferPacketListeners;
@@ -97,12 +97,9 @@ public class EthernetInterface
         
         arpCache = new ARPCache(ARP_CACHE_CLEAN_TIMEOUT);
         
-        arpCacheCleanExecutorService.scheduleAtFixedRate(new Runnable() {
-            @Override
-            public void run() {
-                arpCache.clean();
-            }
-        }, ARP_CACHE_CLEAN_TIMEOUT, ARP_CACHE_CLEAN_TIMEOUT, TimeUnit.SECONDS);
+        arpCacheCleanExecutorService.scheduleAtFixedRate(
+                () -> arpCache.clean(),
+                ARP_CACHE_CLEAN_TIMEOUT, ARP_CACHE_CLEAN_TIMEOUT, TimeUnit.SECONDS);
         
         transferPacketListeners = new ArrayList<TransferPacketListener>();
     }
@@ -158,7 +155,7 @@ public class EthernetInterface
         if(router == null /*||
            !(packet instanceof Layer2Packet)*/)
         {
-            rxDroped++;
+            rxDroped.incrementAndGet();
             return;
         }
 
@@ -176,13 +173,13 @@ public class EthernetInterface
                     {
                         case ARPPacket.REQUEST :
                             try
-                            {        
+                            {
                                 processArpRequest(arpPacket);
                             }catch(AddressException ae)
                             {
                                 ae.printStackTrace();
                             }
-                            rxPackets++;
+                            rxPackets.incrementAndGet();
                             break;
                         case ARPPacket.REPLAY :
                             try
@@ -192,29 +189,28 @@ public class EthernetInterface
                             {
                                 ae.printStackTrace();
                             }
-                            rxPackets++;
+                            rxPackets.incrementAndGet();
                             break;
                         default :
-                            rxPacketsErrors++;
+                            rxPacketsErrors.incrementAndGet();
                     }
                     break;
-                    
+
                 case Protocols.IP :
                     router.routePacket((Packet)l2packet.getData());
-                    rxPackets++;
+                    rxPackets.incrementAndGet();
                     break;
 
                 default :
-                    rxPacketsErrors++;
+                    rxPacketsErrors.incrementAndGet();
             }
         }
         
-        for(Iterator<TransferPacketListener> i = transferPacketListeners.iterator(); i.hasNext(); )
+        for (TransferPacketListener listener : transferPacketListeners)
         {
-            TransferPacketListener listener = i.next();
             listener.packetTransfered(l2packet);
             listener.packetReceived(l2packet);
-        }        
+        }
     }
 
 
@@ -225,16 +221,15 @@ public class EthernetInterface
         if(media != null)
         {
             media.transmitPacket(this, packet);
-            txPackets++;
-            for(Iterator<TransferPacketListener> i = transferPacketListeners.iterator(); i.hasNext(); )
+            txPackets.incrementAndGet();
+            for (TransferPacketListener listener : transferPacketListeners)
             {
-                TransferPacketListener listener = i.next();
                 listener.packetTransfered(packet);
                 listener.packetTransmitted(packet);
-            }            
+            }
         }else
         {
-            txPacketsErrors++;
+            txPacketsErrors.incrementAndGet();
         }
     }
 
@@ -412,43 +407,43 @@ public class EthernetInterface
 
     public int getRXBytes()
     {
-        return rxBytes;
+        return rxBytes.get();
     }
 
     public int getRXDroped()
     {
-        return rxDroped;
+        return rxDroped.get();
     }
 
     public int getRXPackets()
     {
-        return rxPackets;
+        return rxPackets.get();
     }
 
     public int getRXPacketsErrors()
     {
-        return rxPacketsErrors;
+        return rxPacketsErrors.get();
     }
-    
-    
+
+
     public int getTXBytes()
     {
-        return txBytes;
+        return txBytes.get();
     }
 
     public int getTXDroped()
     {
-        return txDroped;
+        return txDroped.get();
     }
 
     public int getTXPackets()
     {
-        return txPackets;
+        return txPackets.get();
     }
 
     public int getTXPacketsErrors()
     {
-        return txPacketsErrors;
+        return txPacketsErrors.get();
     }
     
     

--- a/src/main/java/org/netsimulator/net/Hub.java
+++ b/src/main/java/org/netsimulator/net/Hub.java
@@ -22,7 +22,6 @@ package org.netsimulator.net;
 import org.netsimulator.util.IdGenerator;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 
 public class Hub implements Concentrator
 {
@@ -81,15 +80,14 @@ public class Hub implements Concentrator
     public Port getPortById(int id)
     {
         Port port = null;
-        for(Iterator<Port> i = ports.iterator(); i.hasNext(); )
+        for (Port p : ports)
         {
-            port = i.next();
-            if(port.getId() == id)
+            if (p.getId() == id)
             {
-                return port;
+                return p;
             }
         }
-        return null;        
+        return null;
     }
     
     
@@ -119,10 +117,9 @@ public class Hub implements Concentrator
 
     public void transportPacket(Port sourcePort, Layer2Packet packet)
     {
-        for(Iterator<Port> i=ports.iterator(); i.hasNext();)
+        for (Port port : ports)
         {
-            Port port = i.next();
-            if(port != sourcePort)
+            if (port != sourcePort)
             {
                 port.transmitPacket(packet);
             }

--- a/src/main/java/org/netsimulator/net/ICMPEchoPacket.java
+++ b/src/main/java/org/netsimulator/net/ICMPEchoPacket.java
@@ -86,6 +86,11 @@ public class ICMPEchoPacket extends IP4Packet {
      * @throws AddressException 
      */
     public ICMPEchoPacket getICMPReplay() throws AddressException {
+        if (getSourceAddress() == null) {
+            logger.warning("Cannot create ICMP echo reply: original packet has no source address, reply cannot be routed.");
+            return null;
+        }
+
         ICMPEchoPacket replay
                 = new ICMPEchoPacket(
                         Protocols.ICMPEchoReply,
@@ -94,7 +99,7 @@ public class ICMPEchoPacket extends IP4Packet {
                         getTotalLength(),
                         DEFAULT_TTL,
                         null,
-                        getSourceAddress() == null ? getDestinationAddress() : getSourceAddress(),
+                        getSourceAddress(),
                         getTimestamp(),
                         getData()
                 );

--- a/src/main/java/org/netsimulator/net/IP4Packet.java
+++ b/src/main/java/org/netsimulator/net/IP4Packet.java
@@ -23,13 +23,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * The class implements pseudo IP-packet as it is described in RFC 791.
  *
- * Version 1, 2004-06-30
- *
- * Some exceptions: a) not implements TOS b) not implements fragmentation c)
- * header checksum is never computed, it is 0 every time d) not implements
- * Options (so we do not need Padding) e) version is always 4 f) Internet Header
- * Length is always 5
- *
+ * Some exceptions from the RFC:
+ *   a) does not implement TOS
+ *   b) does not implement fragmentation
+ *   c) header checksum is never computed, it is 0 every time
+ *   d) does not implement Options (so we do not need Padding)
+ *   e) version is always 4
+ *   f) Internet Header length is always 5
  */
 public class IP4Packet implements Packet, Content {
 
@@ -53,23 +53,17 @@ public class IP4Packet implements Packet, Content {
         this.version = 4;
         this.ihl = 5;
         this.headerChecksum = 0;
-        this.data = null;
+        this.data = data;
 
         this.totalLength = totalLength;
         this.ttl = new AtomicInteger(ttl);
         this.protocol = protocol;
 
-        if (srcAddress != null && !(srcAddress instanceof IP4Address)) {
-            throw new AddressException("Invalid source IP4 address.");
-        } else {
-            this.srcAddress = (IP4Address) srcAddress;
-        }
+        assert srcAddress == null || srcAddress instanceof IP4Address : "Invalid source IP4 address.";
+        this.srcAddress = srcAddress;
 
-        if (dstAddress == null || !(dstAddress instanceof IP4Address)) {
-            throw new AddressException("Invalid destination IP4 address.");
-        } else {
-            this.dstAddress = (IP4Address) dstAddress;
-        }
+        assert dstAddress == null || dstAddress instanceof IP4Address : "Invalid destination IP4 address.";
+        this.dstAddress = dstAddress;
 
     }
 
@@ -122,10 +116,7 @@ public class IP4Packet implements Packet, Content {
     }
 
     public void setSourceAddress(IP4Address srcAddress) throws AddressException {
-        if (srcAddress != null && !(srcAddress instanceof IP4Address)) {
-            throw new AddressException("Invalid source IP4 address.");
-        } else {
-            this.srcAddress = (IP4Address) srcAddress;
-        }
+        assert srcAddress == null || srcAddress instanceof IP4Address : "Invalid source IP4 address.";
+        this.srcAddress = srcAddress;
     }
 }

--- a/src/main/java/org/netsimulator/net/IP4Router.java
+++ b/src/main/java/org/netsimulator/net/IP4Router.java
@@ -23,7 +23,6 @@ package org.netsimulator.net;
 import org.netsimulator.util.IdGenerator;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.logging.Logger;
 
 public class IP4Router implements Router {
@@ -55,8 +54,8 @@ public class IP4Router implements Router {
             throw new TooManyInterfacesException( "You can not create more than 256 interfaces!" );
         }
 
-        this.id = idGenerator.getNextId();
         this.id = id;
+        this.idGenerator = idGenerator;
 
         long address_v = this.id;
         address_v = address_v << 8;
@@ -192,14 +191,13 @@ public class IP4Router implements Router {
     }
 
     private void processICMPEchoReplay( ICMPEchoPacket packet ) {
-        for( Iterator<ICMPEchoReplayListener> i = icmpReplayListeners.iterator(); i.hasNext();) {
-            ICMPEchoReplayListener listener = i.next();
+        for ( ICMPEchoReplayListener listener : icmpReplayListeners ) {
             listener.processICMPEchoReplay( packet );
         }
     }
 
     private void processIP4Packet( IP4Packet packet ) {
-
+        logger.warning( getId() + ": UDP packet addressed to this host — not implemented, discarding: " + packet );
     }
 
     private void goThroughRoutingTable( IP4Packet packet ) {
@@ -241,6 +239,10 @@ public class IP4Router implements Router {
                                 } catch( AddressException ae ) {
                                     System.err.println( "Internal error: can not make ICMPEchoReplay packet" );
                                     ae.printStackTrace();
+                                    break;
+                                }
+                                if( replay == null ) {
+                                    logger.warning( getId() + ": ICMP echo reply could not be created (no source address), dropping." );
                                     break;
                                 }
                                 goThroughRoutingTable( replay );

--- a/src/main/java/org/netsimulator/net/RoutingTableRow.java
+++ b/src/main/java/org/netsimulator/net/RoutingTableRow.java
@@ -25,8 +25,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 
 package org.netsimulator.net;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.Comparator;
 import java.util.logging.Logger;
@@ -193,11 +193,11 @@ public class RoutingTableRow
 
     private void setInterface(Interface iface)
     {
-        if(target == null)
+        if(iface == null)
         {
             throw new IllegalArgumentException("The interface can't be null");
         }else
-        {        
+        {
             this.iface = iface;
         }
     }
@@ -261,15 +261,20 @@ public class RoutingTableRow
                 res = EQ;
             } else
             {
-                if( r1.getNetmask().equals(r2.getNetmask()) ) 
+                if( r1.getNetmask().equals(r2.getNetmask()) )
                 {
-                    if(r1.getMetric() <= r2.getMetric())
+                    if(r1.getMetric() < r2.getMetric())
                     {
                         res = LT; // r1 has higher priority than r2
-                    }else
+                    } else if(r1.getMetric() > r2.getMetric())
                     {
                         res = GT; // r1 has lower priority than r2
-                    }    
+                    } else
+                    {
+                        // metrics equal — use interface name as stable tie-breaker
+                        int nameCmp = r1.getInterface().getName().compareTo(r2.getInterface().getName());
+                        res = nameCmp < 0 ? LT : GT;
+                    }
                 }
                 else if( countNetmaskLength(r1.getNetmask()) >
                          countNetmaskLength(r2.getNetmask()) )

--- a/src/main/java/org/netsimulator/net/Switch.java
+++ b/src/main/java/org/netsimulator/net/Switch.java
@@ -23,7 +23,6 @@ import org.netsimulator.util.ConfigurableThreadFactory;
 import org.netsimulator.util.IdGenerator;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -78,12 +77,9 @@ public class Switch implements Concentrator
             ports.add(new Port(idGenerator, this));
         }
         macTable = new MACAddressesTable(MACADDRESS_TABLE_CLEAN_TIMEOUT);
-        macTableCleanExecutorService.scheduleAtFixedRate(new Runnable() {
-            @Override
-            public void run() {
-                macTable.clean();
-            }
-        }, MACADDRESS_TABLE_CLEAN_TIMEOUT, MACADDRESS_TABLE_CLEAN_TIMEOUT, TimeUnit.SECONDS);
+        macTableCleanExecutorService.scheduleAtFixedRate(
+                () -> macTable.clean(),
+                MACADDRESS_TABLE_CLEAN_TIMEOUT, MACADDRESS_TABLE_CLEAN_TIMEOUT, TimeUnit.SECONDS);
         
     }
 
@@ -92,16 +88,14 @@ public class Switch implements Concentrator
     
     public Port getPortById(int id)
     {
-        Port port = null;
-        for(Iterator<Port> i = ports.iterator(); i.hasNext(); )
+        for (Port port : ports)
         {
-            port = i.next();
-            if(port.getId() == id)
+            if (port.getId() == id)
             {
                 return port;
             }
         }
-        return null;        
+        return null;
     }
     
     
@@ -186,7 +180,7 @@ public class Switch implements Concentrator
 
     private void sendToAllPorts(int srcPortId, final Layer2Packet packet)
     {
-        Port portsArray[] = new Port[ ports.size() ];
+        Port[] portsArray = new Port[ ports.size() ];
         ports.toArray( portsArray );
         for( int i = 0; i != portsArray.length; i++ )
         {

--- a/src/main/java/org/netsimulator/term/IfconfigCLICommand.java
+++ b/src/main/java/org/netsimulator/term/IfconfigCLICommand.java
@@ -52,7 +52,7 @@ public class IfconfigCLICommand extends AbstractCommand
             
     private Writer writer;
     private final IP4Router router;
-    private static final Options options = new Options();
+    private final Options options;
 
     private static final Logger LOGGER = 
             Logger.getLogger(IfconfigCLICommand.class.getName());
@@ -60,6 +60,7 @@ public class IfconfigCLICommand extends AbstractCommand
     
     public IfconfigCLICommand(IP4Router router) {
         this.router = router;
+        this.options = new Options();
 
         Option help = new Option("h", false, "display this help");
         options.addOption(help);
@@ -70,15 +71,17 @@ public class IfconfigCLICommand extends AbstractCommand
         options.addOption(statusUp);
         options.addOption(statusDown);
         
-        Option broadcast = OptionBuilder.withArgName( "address" )
-                                        .hasArg()
-                                        .withDescription( "set the protocol broadcast address for this interface" )
-                                        .create( "broadcast" );
+        Option broadcast = Option.builder("broadcast")
+                                 .argName("address")
+                                 .hasArg()
+                                 .desc("set the protocol broadcast address for this interface")
+                                 .build();
         options.addOption(broadcast);
-        Option netmask   = OptionBuilder.withArgName( "address" )
-                                        .hasArg()
-                                        .withDescription( "set the IP network mask for this interface (this value defaults to the usual class A, B or C network mask)" )
-                                        .create( "netmask" );
+        Option netmask   = Option.builder("netmask")
+                                 .argName("address")
+                                 .hasArg()
+                                 .desc("set the IP network mask for this interface (this value defaults to the usual class A, B or C network mask)")
+                                 .build();
         options.addOption(netmask);
      }
 
@@ -94,7 +97,7 @@ public class IfconfigCLICommand extends AbstractCommand
     {
         int retCode = OK_RETCODE;
         try {
-            CommandLineParser parser = new GnuParser();
+            CommandLineParser parser = new DefaultParser();
             CommandLine cmd = null;
             try {
                 cmd = parser.parse( options, argv);

--- a/src/main/java/org/netsimulator/term/PingCLICommand.java
+++ b/src/main/java/org/netsimulator/term/PingCLICommand.java
@@ -34,31 +34,34 @@ public class PingCLICommand extends AbstractCommand implements ICMPEchoReplayLis
 
     private PrintWriter writer;
     private final IP4Router router;
-    private static final Options options = new Options();
-    private boolean go = false;
+    private final Options options;
+    private volatile boolean go = false;
     private ICMPEchoPacket icmpEchoReplayPacket = null;
     private final int identifier;
-    private boolean timeoutExpired = false;
+    private volatile boolean timeoutExpired = false;
     private static final Timer TIMER = new Timer("PingResponceTimeoutThread", true);
     private TimerTaskPing timerTask;
 
 
     public PingCLICommand(IP4Router router) {
         this.router = router;
+        this.options = new Options();
 
         Option help = new Option("h", false, "display this help");
         options.addOption(help);
 
-        Option ttl = OptionBuilder.withArgName("ttl")
+        Option ttl = Option.builder("t")
+                .argName("ttl")
                 .hasArg()
-                .withDescription("set the IP Time to Live")
-                .create("t");
+                .desc("set the IP Time to Live")
+                .build();
         options.addOption(ttl);
 
-        Option interval = OptionBuilder.withArgName("interval")
+        Option interval = Option.builder("i")
+                .argName("interval")
                 .hasArg()
-                .withDescription("wait interval seconds between sending each packet, the default is to wait for one second")
-                .create("i");
+                .desc("wait interval seconds between sending each packet, the default is to wait for one second")
+                .build();
         options.addOption(interval);
         router.addICMPEchoReplayListener(this);
 
@@ -77,7 +80,7 @@ public class PingCLICommand extends AbstractCommand implements ICMPEchoReplayLis
 
         go = true;
 
-        CommandLineParser parser = new GnuParser();
+        CommandLineParser parser = new DefaultParser();
         CommandLine cmd = null;
         try {
             cmd = parser.parse(options, argv);

--- a/src/main/java/org/netsimulator/util/ConfigurableThreadFactory.java
+++ b/src/main/java/org/netsimulator/util/ConfigurableThreadFactory.java
@@ -45,7 +45,7 @@ public class ConfigurableThreadFactory implements ThreadFactory {
                 r,
                 namePrefix + threadNumber.getAndIncrement(),
                 0);
-        if (t.isDaemon()) {
+        if (!t.isDaemon()) {
             t.setDaemon(true);
         }
         if (t.getPriority() != Thread.NORM_PRIORITY) {

--- a/src/test/java/org/netsimulator/net/IP4AddressTest.java
+++ b/src/test/java/org/netsimulator/net/IP4AddressTest.java
@@ -18,7 +18,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 */
 package org.netsimulator.net;
 
-import org.junit.*;
+import org.junit.Test;
 
 import static org.junit.Assert.*;
 
@@ -31,23 +31,8 @@ public class IP4AddressTest {
     public IP4AddressTest() {
     }
     
-    @BeforeClass
-    public static void setUpClass() {
-    }
-    
-    @AfterClass
-    public static void tearDownClass() {
-    }
-    
-    @Before
-    public void setUp() {
-    }
-    
-    @After
-    public void tearDown() {
-    }
 
-    
+
     /**
      * Test string parsing.
      */

--- a/src/test/java/org/netsimulator/net/RoutingTableTest.java
+++ b/src/test/java/org/netsimulator/net/RoutingTableTest.java
@@ -26,18 +26,25 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 
 package org.netsimulator.net;
 
-import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
 import org.netsimulator.util.IdGenerator;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  *
  * @author maks
  */
-public class RoutingTableTest extends TestCase
+public class RoutingTableTest
 {
 
-   
-    public void testRoute() throws AddressException, NotAllowedAddressException 
+    @Before
+    public void setUp() {
+    }
+
+    @Test
+    public void testRoute() throws AddressException, NotAllowedAddressException
     {
         //////// готовим тестовые данные  ////////
         


### PR DESCRIPTION
- Upgrade commons-cli 1.4→1.9.0, migrate commons-lang→commons-lang3 3.14.0, xercesImpl 2.12.0→2.12.2, maven-assembly-plugin 2.5.3→3.7.1
- Replace deprecated OptionBuilder/GnuParser with Option.builder/DefaultParser
- Replace raw int counters with AtomicInteger in EthernetInterface for thread safety
- Fix ARPCache lock usage: tryLock→lock to prevent silent data loss under contention
- Fix inverted daemon-thread guard in ConfigurableThreadFactory
- Fix null-check bug in RoutingTableRow.setInterface (checked wrong field)
- Fix routing comparator to use stable tie-breaker when metrics are equal
- Add null-source guard in ICMPEchoPacket.getICMPReplay; handle null reply in IP4Router
- Replace anonymous Runnable/Iterator patterns with lambdas and enhanced for-loops
- Migrate RoutingTableTest from JUnit 3 to JUnit 4 style; remove empty lifecycle methods