### PR TITLE
Fix image export cutting off shapes near edges

### DIFF
--- a/src/main/java/org/netsimulator/gui/NetworkPanel.java
+++ b/src/main/java/org/netsimulator/gui/NetworkPanel.java
@@ -26,7 +26,10 @@ import java.awt.*;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.ConcurrentModificationException;
+import java.util.Iterator;
 
 public class NetworkPanel
 extends JPanel
@@ -560,33 +563,25 @@ implements MouseListener, Runnable
     public Rectangle getContentBounds()
     {
         final int gap = 30;
-        int x1=0, y1=0, x2=0, y2=0;
-        int x[] = { 0 }, y[] = { 0 };
         Collection<NetworkShape> c = getDevicesLayer();
-        
-        if( c.size() > 0 )
+
+        if( c.isEmpty() )
         {
-            x = new int[ c.size() ];
-            y = new int[ c.size() ];
+            return new Rectangle(0, 0, 0, 0);
         }
-        
-        int i = 0;
+
+        int x1 = Integer.MAX_VALUE, y1 = Integer.MAX_VALUE;
+        int x2 = Integer.MIN_VALUE, y2 = Integer.MIN_VALUE;
+
         for( NetworkShape shape : c )
         {
-            x[i] = (int)shape.getMinX(); 
-            x[i] = (int)shape.getMaxX();
-            y[i] = (int)shape.getMinY();
-            y[i] = (int)shape.getMaxY();
-            i++;
+            x1 = Math.min(x1, (int)shape.getMinX());
+            y1 = Math.min(y1, (int)shape.getMinY());
+            x2 = Math.max(x2, (int)shape.getMaxX());
+            y2 = Math.max(y2, (int)shape.getMaxY());
         }
-        
-        Arrays.sort(x);
-        Arrays.sort(y);
-        
-        x1 = x[0] - gap; x2 = x[ x.length - 1 ] + gap;
-        y1 = y[0] - gap; y2 = y[ y.length - 1 ] + gap;
-        
-        return new Rectangle(x1, y1, x2-x1, y2-y1);
+
+        return new Rectangle(x1 - gap, y1 - gap, x2 - x1 + 2 * gap, y2 - y1 + 2 * gap);
     }
 
     


### PR DESCRIPTION
## Summary

- `getContentBounds()` was overwriting `x[i]`/`y[i]` with both min and max coordinates in the same loop iteration, so only the max survived. Sorting and picking `x[0]` as the minimum then returned a wrong bound, clipping shapes near the left/top edge during image export.
- Replaced the sort-based approach with a direct min/max scan using `Integer.MAX_VALUE`/`MIN_VALUE` sentinels — simpler and correct.
- Added an early return of an empty rectangle when there are no shapes.
- Cleaned up `java.util.*` wildcard import.

Fixes #3.

## Test plan

- [ ] Export an image with devices placed near the left and top edges — verify they are no longer cut off.
- [ ] Export an image with devices only near the right/bottom edges — verify the bounding box is still tight.
- [ ] Export with an empty canvas — verify no exception is thrown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)